### PR TITLE
return optional server id, fix for 0.4 changes

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,14 @@
-addprocs(1)
+srvrscript = joinpath(dirname(@__FILE__), "srvr.jl")
+srvrcmd = `$(joinpath(JULIA_HOME, "julia")) $(srvrscript)`
+println("spawining $srvrcmd")
+srvrproc = spawn(srvrcmd)
 
-@spawnat 2 include("srvr.jl")
 include("clnt.jl")
+println("stopping server process")
+kill(srvrproc)
+
+addprocs(1)
+@spawnat 2 include("srvrfn.jl")
 
 tic()
 for idx in 1:NCALLS
@@ -10,3 +17,4 @@ for idx in 1:NCALLS
 end
 t = toc()
 println("time for $NCALLS calls with remotecall_fetch: $t secs @ $(t/NCALLS) per call")
+

--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -1,18 +1,7 @@
 using JuliaWebAPI
-using Compat
 using Logging
 
-function testfn1(arg1, arg2; narg1=1, narg2=2)
-    a1 = isa(arg1, Int) ? arg1 : parse(Int, arg1)
-    a2 = isa(arg2, Int) ? arg2 : parse(Int, arg2)
-    na1 = isa(narg1, Int) ? narg1 : parse(Int, narg1)
-    na2 = isa(narg2, Int) ? narg2 : parse(Int, narg2)
-    return (a1 * na1) + (a2 * na2)
-end
-testfn2(arg1, arg2; narg1=1, narg2=2) = testfn1(arg1, arg2; narg1=narg1, narg2=narg2)
-
-testbinary(datalen::AbstractString) = testbinary(@compat(parse(Int,datalen)))
-testbinary(datalen::Int) = rand(UInt8, datalen)
+include("srvrfn.jl")
 
 const JSON_RESP_HDRS = @compat Dict{AbstractString,AbstractString}("Content-Type" => "application/json; charset=utf-8")
 const BINARY_RESP_HDRS = @compat Dict{AbstractString,AbstractString}("Content-Type" => "application/octet-stream")

--- a/test/srvrfn.jl
+++ b/test/srvrfn.jl
@@ -1,0 +1,13 @@
+using Compat
+
+function testfn1(arg1, arg2; narg1=1, narg2=2)
+    a1 = isa(arg1, Int) ? arg1 : parse(Int, arg1)
+    a2 = isa(arg2, Int) ? arg2 : parse(Int, arg2)
+    na1 = isa(narg1, Int) ? narg1 : parse(Int, narg1)
+    na2 = isa(narg2, Int) ? narg2 : parse(Int, narg2)
+    return (a1 * na1) + (a2 * na2)
+end
+testfn2(arg1, arg2; narg1=1, narg2=2) = testfn1(arg1, arg2; narg1=narg1, narg2=narg2)
+
+testbinary(datalen::AbstractString) = testbinary(@compat(parse(Int,datalen)))
+testbinary(datalen::Int) = rand(UInt8, datalen)


### PR DESCRIPTION
The API server now returns an optional server/node id with the response, as `nid` element of the return dict. This can be used to identify the server instance that responded to a request.

Also fix the `runtests.jl` and example in `README.md` for Julia 0.4 changes.