### PR TITLE
send ack before terminating

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -96,6 +96,7 @@ function process(conn::APIResponder)
         if startswith(cmd, ':')    # is a control command
             ctrlcmd = symbol(cmd[2:end])
             if ctrlcmd === :terminate
+                respond(conn, Nullable{APISpec}(), :terminate, "")
                 break
             else
                 err("invalid control command $cmd")

--- a/src/JuliaWebAPI.jl
+++ b/src/JuliaWebAPI.jl
@@ -14,6 +14,7 @@ const ERR_CODES = @compat Dict{Symbol, Array}(:success            => [200,  0, "
                         :invalid_api        => [404, -1, "invalid api"],
                         :api_exception      => [500, -2, "api exception"],
                         :invalid_data       => [500, -3, "invalid data"],
+                        :terminate          => [200, 0,  ""],
                         :dummy              => []
                     )
 


### PR DESCRIPTION
Helps a client know which instance terminated and clean up accordingly. Useful while managing state of multiple API processors.