### PR TITLE
support post data, change log level/filename 

### DIFF
--- a/src/APIInvoker.jl
+++ b/src/APIInvoker.jl
@@ -47,7 +47,7 @@ function httpresponse(resp::Dict)
         end
     end
     data = get(resp, "data", "")
-    respdata = isa(data, Array) ? convert(Array{Uint8}, data) :
+    respdata = isa(data, Array) ? convert(Array{UInt8}, data) :
                isa(data, Dict) ? JSON.json(data) :
                string(data)
     Response(resp["code"], hdrs, respdata)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ addprocs(1)
 tic()
 for idx in 1:NCALLS
     arg1,arg2,narg1,narg2 = APIARGS[(4*idx-3):(4*idx)]
-    @test remotecall_fetch(2, (a1,a2,a3,a4)->(a1*a3 + a2*a4), arg1, arg2, narg1, narg2) == (arg1 * narg1) + (arg2 * narg2)
+    @test remotecall_fetch((a1,a2,a3,a4)->(a1*a3 + a2*a4), 2, arg1, arg2, narg1, narg2) == (arg1 * narg1) + (arg2 * narg2)
 end
 t = toc()
 println("time for $NCALLS calls with remotecall_fetch: $t secs @ $(t/NCALLS) per call")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+using JuliaWebAPI
+using Logging
+using Base.Test
+using Compat
+
 srvrscript = joinpath(dirname(@__FILE__), "srvr.jl")
 srvrcmd = `$(joinpath(JULIA_HOME, "julia")) $(srvrscript)`
 println("spawining $srvrcmd")


### PR DESCRIPTION
Based on @mdpradeep's changes from #15 

- RESTServer, which uses a Julia webserver to provide a HTTP interface can now parse POST data (name=value format)
- Log file name now includes the container id to prevent containers from clobbering each other's logs. 