### PR TITLE
prepare for move to JuliaWeb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+    - osx
+    - linux
+julia:
+    - nightly
+    - 0.4
+    - 0.3
 notifications:
-  email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    email: false
 script:
-  - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("JuliaWebAPI")'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("JuliaWebAPI"); Pkg.test("JuliaWebAPI"; coverage=true)';
+after_success:
+  - julia -e 'cd(Pkg.dir("JuliaWebAPI")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'cd(Pkg.dir("JuliaWebAPI")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JuliaWebAPI.jl
 
-[![Build Status](https://travis-ci.org/tanmaykm/JuliaWebAPI.jl.png)](https://travis-ci.org/tanmaykm/JuliaWebAPI.jl)
+[![Build Status](https://travis-ci.org/JuliaWeb/JuliaWebAPI.jl.png)](https://travis-ci.org/JuliaWeb/JuliaWebAPI.jl)
 
 Facilitates wrapping Julia functions into a remote callable API via ZMQ and HTTP.
 Combined with [JuliaBox](https://juliabox.org/), it helps deploy Julia packages and code snippets as publicly hosted, auto-scaling REST APIs.

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -1,10 +1,13 @@
 using JuliaWebAPI
 using Logging
+using ZMQ
 using Base.Test
 
 Logging.configure(level=INFO)
 
-const apiclnt = APIInvoker("tcp://127.0.0.1:9999")
+const ctx = Context()
+
+const apiclnt = APIInvoker("tcp://127.0.0.1:9999", ctx)
 
 const NCALLS = 100
 
@@ -53,3 +56,5 @@ for idx in 1:100
 end
 t = toc();
 println("time for $NCALLS calls to testbinary: $t secs @ $(t/NCALLS) per call")
+
+close(ctx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ for idx in 1:NCALLS
 end
 t = toc()
 println("time for $NCALLS calls with remotecall_fetch: $t secs @ $(t/NCALLS) per call")
-
+rmprocs(workers())
+println("stopped all workers")


### PR DESCRIPTION
- newer style travis
- links to point to JuliaWeb
- runtests.jl closes zmqcontext and stops workers before exit to avoid segfault on Julia 0.3